### PR TITLE
ECPAPPSERVERJBOSS-163 Renaming "JBoss AS URL" to "JBoss controller location"

### DIFF
--- a/src/main/resources/project/JBossEditConfigForm.xml
+++ b/src/main/resources/project/JBossEditConfigForm.xml
@@ -1,7 +1,7 @@
 <editor>
     <formElement>
         <type>entry</type>
-        <label>JBoss AS URL:</label>
+        <label>JBoss controller location:</label>
         <property>jboss_url</property>
         <value></value>
         <documentation>JBoss controller location. For example: localhost:9999. You can find this information in "$JBOSS_HOME/bin/jboss-cli.xml". If secured connection is being used, see <a href="/commander/pages/@PLUGIN_KEY@-@PLUGIN_VERSION@/EC-JBoss_help#known-issues" target="_BLANK">Known Issues</a> section in the documentation.


### PR DESCRIPTION
ECPAPPSERVERJBOSS-163 Renaming "JBoss AS URL" to "JBoss controller location" on edit JBoss config page (in accordance with create JBoss config page)