### PR TITLE
Add JBoss EAP 6.3 to the list of supported versions

### DIFF
--- a/pages/EC-JBoss_help.xml
+++ b/pages/EC-JBoss_help.xml
@@ -87,6 +87,7 @@
                     <li>JBoss EAP 6.0 on Linux and Windows</li>
                     <li>JBoss EAP 6.1 on Linux and Windows</li>
                     <li>JBoss EAP 6.2 on Linux and Windows</li>
+                    <li>JBoss EAP 6.3 on Linux and Windows</li>
                     <li>JBoss EAP 6.4 on Linux and Windows</li>
                     <li>JBoss EAP 7.0 on Linux and Windows</li>
                     <li>JBoss EAP 7.1 on Linux and Windows</li>


### PR DESCRIPTION
@colathurv , could you please confirm if we need to add JBoss EAP 6.3 to the list of supported versions?