### PR TITLE
ECPAPPSERVERJBOSS-790

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 
 group = "com.electriccloud"
 description = "Plugins : EC-JBoss"
-version = "2.6.1"
+version = "2.6.2"
 
 apply plugin: 'flow-gradle-plugin'
 apply plugin: 'license'

--- a/pages/EC-JBoss_help.xml
+++ b/pages/EC-JBoss_help.xml
@@ -20,7 +20,7 @@
                  ideas, examples, and so on. It is OK to copy them word-for-word only if it is appropriate, such as FOSS.
                  However, do not do this with commercial software. -->
 
-            <p>Revised on January 24, 2019</p>
+            <p>Revised on February 14, 2019</p>
 
             <h1>Contents</h1>
             <p>
@@ -2679,6 +2679,10 @@
             "JBAS010839: Operation failed or was rolled back on all servers." (in Domain)
             <br/>
             <h1 id="rns">Release Notes</h1>
+            <h2>@PLUGIN_KEY@ 2.6.2</h2>
+            <ul>
+                <li>Fixed the issue with lost output parameters for 9.0: upon upgrade or clean install of 9.0 output parameters were not created for the plugin's procedures.</li>
+            </ul>
             <h2>@PLUGIN_KEY@ 2.6.1</h2>
             <ul>
                 <li>The plugin icon has been updated.</li>

--- a/src/main/resources/project/ec_setup.pl
+++ b/src/main/resources/project/ec_setup.pl
@@ -447,9 +447,10 @@ if ($promoteAction eq 'promote') {
         my $versions = $commander->getVersions();
 
         if (my $version = $versions->findvalue('//version')) {
-            my ( $major, $minor ) = split('\.', $version);
+            require ElectricCommander::Util;
+            ElectricCommander::Util->import('compareMinor');
 
-            if ($major >= 8 && $minor >= 3) {
+            if (compareMinor($version, '8.3') >= 0) {
                 checkAndSetOutputParameters(@formalOutputParameters);
             }
         }


### PR DESCRIPTION
Fixed the issue with lost output parameters for 9.0: upon upgrade or clean install of 9.0 output parameters were not created for the plugin's procedures.