### PR TITLE
Fixed CreateOrUpdateDataSource.Sanity tests

### DIFF
--- a/specs/src/test/groovy/com/electriccloud/plugin/spec/CreateOrUpdateDataSource.groovy
+++ b/specs/src/test/groovy/com/electriccloud/plugin/spec/CreateOrUpdateDataSource.groovy
@@ -383,7 +383,6 @@ class CreateOrUpdateDataSource extends PluginTestHelper {
         assert runProcedureJob.getStatus() == jobExpectedStatus
         assert jobUpperStepSummary =~ summaries.'default'.replace("dsName1", dsName)
         assert procedureLogs =~ jobLogs.'default'.replace("dsName1", dsName)
-        assert !(procedureLogs.contains("profile"))
         checkCreateDataSource(dsName, jndiName, jdbcDriverName, enabled, password, userName, url, additionalOption)
 
         cleanup:
@@ -453,7 +452,6 @@ class CreateOrUpdateDataSource extends PluginTestHelper {
         assert runProcedureJob.getStatus() == jobExpectedStatus
         assert jobUpperStepSummary =~ summaries.'default'.replace("dsName1", dsName)
         assert procedureLogs =~ jobLogs.'default'.replace("dsName1", dsName)
-        assert !(procedureLogs.contains("profile"))
         checkCreateDataSource(dsName, jndiName, jdbcDriverName, enabled, password, userName, url, additionalOption)
 
         cleanup:
@@ -608,7 +606,6 @@ class CreateOrUpdateDataSource extends PluginTestHelper {
         assert runProcedureJob.getStatus() == jobExpectedStatus
         assert jobUpperStepSummary =~ summary
         assert procedureLogs =~ logs
-        assert !(procedureLogs.contains("profile"))
         checkCreateDataSource(dsName, jndiName, jdbcDriverName, enabled, password, userName, url, additionalOption)
 
         cleanup:


### PR DESCRIPTION
Removed occurrences of "assert !(procedureLogs.contains("profile"))" in CreateOrUpdateDataSource.groovy
With plugin v2.8+ this word is always in log of procedures related to these tests and moreover it will appear several times with debug level DEBUG. Above makes assert irrelevant.