### PR TITLE
Fixed StartStandaloneServer - positive[2] test

### DIFF
--- a/specs/src/test/groovy/com/electriccloud/plugin/spec/StartStandaloneServer.groovy
+++ b/specs/src/test/groovy/com/electriccloud/plugin/spec/StartStandaloneServer.groovy
@@ -66,7 +66,7 @@ class StartStandaloneServer extends PluginTestHelper {
     @Shared
     def additionalOptions = [
         'empty': '',
-        'docker': '-b 0.0.0.0 -bmanagement 0.0.0.0 -c standalone-full.xml',
+        'docker': '-b 0.0.0.0 -bmanagement 0.0.0.0',
         'custom path': '-Djboss.server.log.dir=/tmp/qa -b 0.0.0.0 -bmanagement 0.0.0.0',
         'error': '-b 0.0.0.0 -bmanagement error',
         'error and custom path': "-Djboss.server.log.dir=/tmp/qa -b 0.0.0.0 -bmanagement error"

--- a/specs/src/test/groovy/com/electriccloud/plugin/spec/StartStandaloneServer.groovy
+++ b/specs/src/test/groovy/com/electriccloud/plugin/spec/StartStandaloneServer.groovy
@@ -66,7 +66,7 @@ class StartStandaloneServer extends PluginTestHelper {
     @Shared
     def additionalOptions = [
         'empty': '',
-        'docker': '-b 0.0.0.0 -bmanagement 0.0.0.0',
+        'docker': '-b 0.0.0.0 -bmanagement 0.0.0.0 -c standalone-full.xml',
         'custom path': '-Djboss.server.log.dir=/tmp/qa -b 0.0.0.0 -bmanagement 0.0.0.0',
         'error': '-b 0.0.0.0 -bmanagement error',
         'error and custom path': "-Djboss.server.log.dir=/tmp/qa -b 0.0.0.0 -bmanagement error"

--- a/specs/src/test/groovy/com/electriccloud/plugin/spec/StartStandaloneServer.groovy
+++ b/specs/src/test/groovy/com/electriccloud/plugin/spec/StartStandaloneServer.groovy
@@ -67,6 +67,7 @@ class StartStandaloneServer extends PluginTestHelper {
     def additionalOptions = [
         'empty': '',
         'docker': '-b 0.0.0.0 -bmanagement 0.0.0.0 -c standalone-full.xml',
+        'docker no config': '-b 0.0.0.0 -bmanagement 0.0.0.0',
         'custom path': '-Djboss.server.log.dir=/tmp/qa -b 0.0.0.0 -bmanagement 0.0.0.0',
         'error': '-b 0.0.0.0 -bmanagement error',
         'error and custom path': "-Djboss.server.log.dir=/tmp/qa -b 0.0.0.0 -bmanagement error"
@@ -203,10 +204,10 @@ class StartStandaloneServer extends PluginTestHelper {
             assert runCliCommandAndGetJBossReply(CliCommandsGeneratorHelper.getStandaloneStatus()).result == "running"
         }
         where: 'The following params will be: '
-        testCaseId                 | configName         | scriptPath             | standaloneConfig             | additionalOption          	      | jbossShouldBeStopped | logs      			    | summary 				| jobExpectedStatus  | logFileLocation
-        testCases.systemTest1.name | defaultConfigName  | scriptPaths.'default'  | standaloneConfigs.'empty'    | additionalOptions.'docker'	      | true                 | jobLogs.'default'		| summaries.'default'	|	"success"        | logFileLocations.'empty'
-        testCases.systemTest2.name | defaultConfigName  | scriptPaths.'default'  | standaloneConfigs.'empty'    | additionalOptions.'docker'	      | false                | jobLogs.'started'		| summaries.'started'	|	"warning"        | logFileLocations.'empty'
-        testCases.systemTest3.name | defaultConfigName  | scriptPaths.'default'  | standaloneConfigs.'full'     | additionalOptions.'docker'	      | true                 | jobLogs.'full config'	| summaries.'default'	|	"success"        | logFileLocations.'empty'
+        testCaseId                 | configName         | scriptPath             | standaloneConfig             | additionalOption                      | jbossShouldBeStopped | logs      			    | summary 				| jobExpectedStatus  | logFileLocation
+        testCases.systemTest1.name | defaultConfigName  | scriptPaths.'default'  | standaloneConfigs.'empty'    | additionalOptions.'docker'            | true                 | jobLogs.'default'		| summaries.'default'	|	"success"        | logFileLocations.'empty'
+        testCases.systemTest2.name | defaultConfigName  | scriptPaths.'default'  | standaloneConfigs.'empty'    | additionalOptions.'docker'            | false                | jobLogs.'started'		| summaries.'started'	|	"warning"        | logFileLocations.'empty'
+        testCases.systemTest3.name | defaultConfigName  | scriptPaths.'default'  | standaloneConfigs.'full'     | additionalOptions.'docker no config'  | true                 | jobLogs.'full config'	| summaries.'default'	|	"success"        | logFileLocations.'empty'
 // !!!
 //        testCases.systemTest4.name | defaultConfigName  | scriptPaths.'default'  | standaloneConfigs.'empty'    | additionalOptions.'custom path'     | true                 | jobLogs.'custom logs'	| summaries.'default'	|	"success"        | logFileLocations.'empty'
 //        testCases.systemTest4.name | defaultConfigName  | scriptPaths.'default'  | standaloneConfigs.'empty'    | additionalOptions.'custom path'     | true                 | jobLogs.'custom logs'    | summaries.'default'   |   "success"        | logFileLocations.'custom'


### PR DESCRIPTION
Removed  -c standalone-full.xml from additional options, because in 3rd test case there is an attempt to start JBoss with both "--server-config" and "-c" specified which results in immediate failure. JBoss just can't start with both config options specified